### PR TITLE
fix(dredge-route): dredgeRouter not throwing error on duplicate route and more than one dynamic path on same level

### DIFF
--- a/.changeset/mean-meals-wait.md
+++ b/.changeset/mean-meals-wait.md
@@ -1,0 +1,5 @@
+---
+"dredge-route": patch
+---
+
+Fix dredgeRouter not throwing error on duplicate route and more than one dynamic path on same level

--- a/packages/route/source/router.ts
+++ b/packages/route/source/router.ts
@@ -84,6 +84,8 @@ export class RoutePath {
 class DredgeRouterClass<Routes extends AnyRoute[] = []>
   implements DredgeRouter
 {
+  // readonly routes: Routes;
+
   root: RoutePath = new RoutePath({
     name: "$root",
   });
@@ -124,12 +126,21 @@ class DredgeRouterClass<Routes extends AnyRoute[] = []>
 
       let current = this.root;
       paths.forEach((name) => {
-        if (!current.hasChild(name)) {
+        const child = current.getChild(name);
+        if (child && child.isParam && child.name !== name.slice(1)) {
+          throw new Error(`Duplicate dynamic path ${name} in the same level`);
+        }
+
+        if (!child) {
           current.addChild(name);
         }
         current = current.getChild(name)!;
       });
 
+      const endRoute = current.getRoute(def.method!);
+      if (endRoute) {
+        throw new Error(`Duplicate method ${def.method} in the same level`);
+      }
       current.setRoute(route);
     });
   }

--- a/packages/route/test/router.test.ts
+++ b/packages/route/test/router.test.ts
@@ -35,7 +35,7 @@ test("it will return route, if method and path matched", async () => {
     dredgeRoute()
       .path("/post")
       .get()
-      .use((req, res) => {
+      .use((_req, res) => {
         res.end();
       })
       .build(),
@@ -62,4 +62,59 @@ test("it will return route, if method and path matched", async () => {
     method: "post",
     paths: ["post"],
   });
+});
+
+test("it will throw, if more than one dynamic path at same level", async () => {
+  expect(() =>
+    dredgeRouter([
+      dredgeRoute().path("/a/:b").get().build(),
+      dredgeRoute().path("/a/:c").get().build(),
+    ]),
+  ).toThrowError();
+
+  expect(() =>
+    dredgeRouter([
+      dredgeRoute().path("/a/:b/c/d").get().build(),
+      dredgeRoute().path("/a/:c/c/d").get().build(),
+    ]),
+  ).toThrowError();
+});
+
+test("it will throw if two or more route are same", () => {
+  expect(() =>
+    dredgeRouter([
+      dredgeRoute().path("/a").get().build(),
+      dredgeRoute().path("/a").post().build(),
+      dredgeRoute().path("/a/b/c").delete().build(),
+      dredgeRoute().path("/a/b/c").put().build(),
+    ]),
+  ).not.toThrowError();
+
+  expect(() =>
+    dredgeRouter([
+      dredgeRoute().path("/a").get().build(),
+      dredgeRoute().path("/a").get().build(),
+    ]),
+  ).toThrowError();
+
+  expect(() =>
+    dredgeRouter([
+      dredgeRoute().path("/a/:b").get().build(),
+      dredgeRoute().path("/a/:b").post().build(),
+    ]),
+  ).not.toThrowError();
+
+  expect(() =>
+    dredgeRouter([
+      dredgeRoute().path("/a/:b").get().build(),
+      dredgeRoute().path("/a/:b").get().build(),
+    ]),
+  ).toThrowError();
+
+  expect(() =>
+    dredgeRouter([
+      dredgeRoute().path("/a/:b/c/d").get().build(),
+      dredgeRoute().path("/a/:b/c/d").get().build(),
+    ]),
+  ).toThrowError();
 });


### PR DESCRIPTION
route and more than one dynamic path on same level