### PR TITLE
refactor(dredge-route, dredge-types)!: add `res.up()` to dredge-route

### DIFF
--- a/.changeset/tricky-ants-roll.md
+++ b/.changeset/tricky-ants-roll.md
@@ -1,0 +1,6 @@
+---
+"dredge-route": major
+"dredge-types": major
+---
+
+`res.next()` and res.end() are replaced with `res.up()` in dredgeRoute

--- a/packages/adapters/source/direct-client.ts
+++ b/packages/adapters/source/direct-client.ts
@@ -6,7 +6,7 @@ import {
   trimSlashes,
 } from "dredge-common";
 import {
-  MiddlewareRequest,
+  DredgeRequest,
   useErrorMiddlewares,
   useSuccessMiddlewares,
   useValidate,
@@ -82,7 +82,7 @@ export function createDirectClient(
         ? new URL(_options.path, _options.prefixUrl).href
         : _options.path;
 
-      const middlewareRequest: MiddlewareRequest = {
+      const middlewareRequest: DredgeRequest = {
         url,
         method: _options.method,
         headers: _options.headers,

--- a/packages/adapters/source/fetch.ts
+++ b/packages/adapters/source/fetch.ts
@@ -10,7 +10,7 @@ import {
   trimSlashes,
 } from "dredge-common";
 import {
-  MiddlewareRequest,
+  DredgeRequest,
   getPathParams,
   useErrorMiddlewares,
   useSuccessMiddlewares,
@@ -105,7 +105,7 @@ export function createFetchRequestHandler<Context extends object = {}>(
     const parsedParams = deserializeParams(params, routeDef.params);
     const parsedQueries = deserializeQueries(queries, routeDef.queries);
 
-    const middlewareRequest: MiddlewareRequest = {
+    const middlewareRequest: DredgeRequest = {
       url: url.href,
       method: req.method || "get",
       headers,

--- a/packages/adapters/source/node-http.ts
+++ b/packages/adapters/source/node-http.ts
@@ -13,7 +13,7 @@ import {
   trimSlashes,
 } from "dredge-common";
 import {
-  MiddlewareRequest,
+  DredgeRequest,
   getPathParams,
   useErrorMiddlewares,
   useSuccessMiddlewares,
@@ -114,7 +114,7 @@ export function createNodeHttpRequestHandler<Context extends object = {}>(
     const parsedParams = deserializeParams(params, routeDef.params);
     const parsedQueries = deserializeQueries(queries, routeDef.queries);
 
-    const middlewareRequest: MiddlewareRequest = {
+    const middlewareRequest: DredgeRequest = {
       url: url.href,
       method: req.method || "get",
       headers,

--- a/packages/adapters/test/adapter.test.ts
+++ b/packages/adapters/test/adapter.test.ts
@@ -46,7 +46,7 @@ describe.each(servers)(
             .path("/success")
             .post()
             .use((req, res) => {
-              return res.end({
+              return res.up({
                 status: 200,
                 json: {
                   ...req.data,
@@ -61,7 +61,7 @@ describe.each(servers)(
               throw "error";
             })
             .error((_err, req, res) => {
-              return res.end({
+              return res.up({
                 status: 500,
                 json: {
                   ...req.data,
@@ -109,7 +109,7 @@ describe.each(servers)(
             .post()
             .input(z.string())
             .use((req, res) => {
-              return res.end({
+              return res.up({
                 status: 200,
                 text: req.data,
               });
@@ -123,7 +123,7 @@ describe.each(servers)(
               throw "error";
             })
             .error((_err, req, res) => {
-              return res.end({
+              return res.up({
                 status: 500,
                 text: req.data,
               });
@@ -175,7 +175,7 @@ describe.each(servers)(
             .path("/fruits")
             .get()
             .use((_req, res) => {
-              return res.end({
+              return res.up({
                 json: data,
               });
             }),
@@ -200,7 +200,7 @@ describe.each(servers)(
             .path("/test-I")
             .get()
             .use((_req, res) => {
-              return res.end({
+              return res.up({
                 status: 200,
               });
             }),
@@ -222,7 +222,7 @@ describe.each(servers)(
             .path("/test/:param")
             .get()
             .use((req, res) => {
-              return res.end({
+              return res.up({
                 status: 200,
                 json: req.param(),
               });
@@ -273,7 +273,7 @@ describe.each(servers)(
             })
             .get()
             .use((req, res) => {
-              return res.end({
+              return res.up({
                 status: 200,
                 json: {
                   single: req.query(),
@@ -332,7 +332,7 @@ describe.each(servers)(
               .input(z.any())
               .post()
               .use((req, res) => {
-                return res.end({
+                return res.up({
                   status: 200,
                   text: req.data,
                 });
@@ -412,7 +412,7 @@ describe.each(servers)(
               .input(z.any())
               .post()
               .use((req, res) => {
-                return res.end({
+                return res.up({
                   status: 200,
                   text: req.data,
                 });
@@ -455,7 +455,7 @@ describe.each(servers)(
               .post()
               .input(z.string())
               .use((req, res) => {
-                return res.end({
+                return res.up({
                   status: 200,
                   headers: {
                     "Content-Type": req.data || req.header("accept") || "",
@@ -544,7 +544,7 @@ describe.each(servers)(
               .post()
               .input(z.string())
               .use((req, res) => {
-                return res.end({
+                return res.up({
                   status: 200,
                   headers: {
                     "Content-Type": req.data || req.header("accept") || "",
@@ -589,7 +589,7 @@ describe.each(servers)(
           .get()
           .use((req, res) => {
             const url = new URL(req.url, "relative:///");
-            return res.end({
+            return res.up({
               status: 200,
               text: url.pathname,
             });
@@ -600,7 +600,7 @@ describe.each(servers)(
           .post()
           .use((req, res) => {
             const url = new URL(req.url, "relative:///");
-            return res.end({
+            return res.up({
               status: 200,
               text: url.pathname,
             });
@@ -652,13 +652,13 @@ describe.each(servers)(
             })
             .get()
             .use((req, res) => {
-              return res.end({
+              return res.up({
                 status: 200,
                 json: req.param(),
               });
             })
             .error((_err, _req, res) => {
-              return res.end({
+              return res.up({
                 status: 400,
               });
             }),
@@ -690,7 +690,7 @@ describe.each(servers)(
             })
             .get()
             .use((req, res) => {
-              return res.end({
+              return res.up({
                 status: 200,
                 json: {
                   single: {
@@ -739,12 +739,12 @@ describe.each(servers)(
             })
             .get()
             .use((_req, res) => {
-              return res.end({
+              return res.up({
                 status: 200,
               });
             })
             .error((_err, _req, res) => {
-              return res.end({
+              return res.up({
                 status: 400,
               });
             }),
@@ -784,7 +784,7 @@ describe.each(servers)(
             .post()
             .input(z.any())
             .use((req, res) => {
-              return res.end({
+              return res.up({
                 headers: {
                   "x-had-req-data": req.data ? "true" : "false",
                 },
@@ -793,7 +793,7 @@ describe.each(servers)(
               });
             })
             .error((_err, _req, res) => {
-              return res.end({
+              return res.up({
                 status: 500,
               });
             }),

--- a/packages/adapters/test/direct-client.test.ts
+++ b/packages/adapters/test/direct-client.test.ts
@@ -22,7 +22,7 @@ describe("client.extend", () => {
         .post()
         .input(z.any())
         .use((req, res) => {
-          return res.end({
+          return res.up({
             data: {
               headers: req.header(),
               dataType: req.dataType,
@@ -157,7 +157,7 @@ test("paramPath should work", async () => {
         .path("/test/:PI/:PII")
         .get()
         .use((req, res) => {
-          return res.end({
+          return res.up({
             data: {
               path: req.url,
             },
@@ -201,7 +201,7 @@ test("throw error if params is empty string", () => {
         .path("/test/:PI/:PII")
         .get()
         .use((req, res) => {
-          return res.end({
+          return res.up({
             data: {
               path: req.url,
             },
@@ -247,7 +247,7 @@ test("throw error if params is empty string", () => {
 //         .path("/test")
 //         .post(z.any())
 //         .use((req, res) => {
-//           return res.end({
+//           return res.up({
 //             data: {
 //               reqContentType: req.header("content-type"),
 //               reqDataType: req.dataType,
@@ -358,7 +358,7 @@ test("throw error if params is empty string", () => {
 //         .get()
 //         .use((req, res) => {
 //           console.log("status", req.param("status"));
-//           return res.end({
+//           return res.up({
 //             data: null,
 //             status: req.param("status"),
 //             statusText: "Bad Request",

--- a/packages/fetch/test/main.test.ts
+++ b/packages/fetch/test/main.test.ts
@@ -22,7 +22,7 @@ const route = dredgeRoute()
     },
   })
   .error((_error, _req, res) => {
-    return res.end({
+    return res.up({
       status: 400,
     });
   });
@@ -91,7 +91,7 @@ const GetBirds = route
   .path("/birds")
   .get()
   .use((_req, res) => {
-    return res.end({
+    return res.up({
       status: 200,
       json: birds,
     });
@@ -101,7 +101,7 @@ const GetBirdByName = route
   .path("/birds/:name")
   .get()
   .use((req, res) => {
-    return res.end({
+    return res.up({
       status: 200,
       json: findBird(req.param("name")),
     });
@@ -112,7 +112,7 @@ const PostBird = route
   .post()
   .input(z.object({ name: z.string(), color: z.string() }))
   .use((_req, res) => {
-    return res.end({
+    return res.up({
       status: 200,
       json: {
         created: true,
@@ -124,7 +124,7 @@ const GetBirdColors = route
   .path("/birds/colors")
   .get()
   .use((_req, res) => {
-    return res.end({
+    return res.up({
       status: 200,
       json: birds.map((bird) => bird.color),
     });
@@ -137,7 +137,7 @@ const GetEventByDate = route
   })
   .get()
   .use((req, res) => {
-    return res.end({
+    return res.up({
       status: 200,
       json: findEvent(req.param("date")),
     });
@@ -147,7 +147,7 @@ const DeleteFruitByName = route
   .path("/fruits/:name")
   .delete()
   .use((_req, res) => {
-    return res.end({
+    return res.up({
       status: 200,
       json: {
         isDeleted: true,
@@ -158,7 +158,7 @@ const DeleteFruitByName = route
 const GetFreshFruits = route
   .path("/fruits/fresh")
   .use((_req, res) => {
-    return res.end({
+    return res.up({
       status: 200,
       json: fruits.filter((fruit) => fruit.isFresh),
     });

--- a/packages/route/source/route.ts
+++ b/packages/route/source/route.ts
@@ -1,4 +1,4 @@
-import { DataTypes, trimSlashes, validateDataTypeName } from "dredge-common";
+import { DataTypes, trimSlashes } from "dredge-common";
 import type { AnyRoute, RouteBuilderDef, Route } from "dredge-types";
 
 export function dredgeRoute<Context extends Record<string, any> = {}>() {

--- a/packages/route/test/router.test.ts
+++ b/packages/route/test/router.test.ts
@@ -37,7 +37,7 @@ test("it will return route, if method and path matched", async () => {
       .path("/post")
       .get()
       .use((_req, res) => {
-        res.end();
+        res.up();
       }),
 
     dredgeRoute().path("/post").post(),

--- a/packages/types/source/client/dredge-client-response.ts
+++ b/packages/types/source/client/dredge-client-response.ts
@@ -1,6 +1,6 @@
-import { Parser, inferParserType } from "../parser";
+import { inferParserType } from "../parser";
 import { AnyRouteOptions, Route } from "../route";
-import { Merge } from "../utils";
+import { IsNever, Merge } from "../utils";
 
 export interface DredgeClientResponse<T = any> {
   headers: Record<string, string>;
@@ -23,7 +23,9 @@ export type DredgeResponsePromise<
   >
 > & {
   [key in DataTypes extends string ? DataTypes : never]: () => Promise<Data>;
-} & { data: () => Promise<Data> };
+} & {
+  data: () => Promise<Data>;
+};
 
 export type inferDredgeResponsePromise<
   R,
@@ -42,7 +44,9 @@ export type inferDredgeResponsePromise<
 >
   ? DredgeResponsePromise<
       keyof Options["dataTypes"],
-      OBody extends Parser ? inferParserType<OBody> : unknown,
+      IsNever<inferParserType<OBody>> extends true
+        ? any
+        : inferParserType<OBody>,
       Response
     >
   : never;

--- a/packages/types/source/route/route-data.ts
+++ b/packages/types/source/route/route-data.ts
@@ -2,27 +2,21 @@ import { Parser, inferParserType } from "../parser";
 import { Route } from "./dredge-route";
 import { IsNever } from "../utils";
 
-export type Data<Types, T> = IsNever<T> extends true
-  ? OptionalData<Types, any>
-  : undefined extends T
+type RequireOne<T, K extends keyof T = keyof T> = K extends keyof T
+  ? Required<Pick<T, K>> & Partial<Omit<T, K>>
+  : never;
+
+export type Data<Types, T> = IsNever<T> extends false
+  ? undefined extends T
     ? OptionalData<Types, T>
-    : RequiredData<Types, T>;
+    : RequireOne<OptionalData<Types, T>>
+  : OptionalData<Types, any>;
 
-export type RequiredData<Types, T> =
-  | { data: T }
-  | (Types extends infer U
-      ? U extends string
-        ? { [P in U]: T }
-        : never
-      : never);
-
-export type OptionalData<Types, T> =
-  | { data?: T }
-  | (Types extends infer U
-      ? U extends string
-        ? { [P in U]?: T }
-        : never
-      : never);
+export type OptionalData<Types, T> = [Types] extends [string]
+  ? {
+      [P in Types | "data"]?: T;
+    }
+  : never;
 
 export type inferRouteEData<R> = R extends Route<
   any,

--- a/packages/types/source/utils.ts
+++ b/packages/types/source/utils.ts
@@ -148,10 +148,9 @@ export type RequiredKeys<Type> = Type extends unknown
   ? Exclude<keyof Type, OptionalKeys<Type>>
   : never;
 
-export type DistributiveIndex<T, K extends PropertyKey> = T extends Record<
-  K,
-  infer V
->
+export type DistributiveIndex<T, K extends PropertyKey> = T extends
+  | { [key in K]: infer V }
+  | { [key in K]?: infer V }
   ? V
   : never;
 

--- a/packages/types/test/client-response.test-d.ts
+++ b/packages/types/test/client-response.test-d.ts
@@ -1,11 +1,15 @@
 import { describe, expectTypeOf, test } from "vitest";
 import { createClient } from "./helpers/dredge-client";
 import { pathRouter } from "./path-routes";
+import { dredgeRouter } from "./helpers/dredge-router";
+import { dredgeRoute } from "./helpers/dredge-route";
+import { z } from "zod";
 
 type PathRouter = typeof pathRouter;
 
 describe("pathRoutes", () => {
   const client = createClient<PathRouter>();
+
   test("/a/b/c/d", async () => {
     expectTypeOf(
       await client.get("/a/b/c/d").data(),
@@ -62,4 +66,128 @@ describe("pathRoutes", () => {
       await client(":/a/:b/c/d", { method: "get", params: { b: 2 } }).data(),
     ).toEqualTypeOf<"GET/a/:b/c/d">();
   });
+});
+
+const r = dredgeRoute().options({
+  dataTypes: {
+    json: "application/json",
+    form: "application/x-www-form-urlencoded",
+    text: "text/plain",
+  },
+});
+
+test("infers `any` when route never return res.up() or pass data to it", async () => {
+  const Router = dredgeRouter([
+    r
+      .path("/up-returned")
+      .get()
+      .use((_req, res) => {
+        return res.up({
+          status: 200,
+        });
+      }),
+    r
+      .path("/no-up-returned")
+      .get()
+      .use(() => {}),
+  ]);
+
+  const client = createClient<typeof Router>();
+
+  expectTypeOf(await client.get("/up-returned").data()).toBeAny();
+  expectTypeOf(await client.get("/no-up-returned").data()).toBeAny();
+
+  expectTypeOf(await client.get("/up-returned").json()).toBeAny();
+  expectTypeOf(await client.get("/no-up-returned").json()).toBeAny();
+
+  expectTypeOf(await client.get("/up-returned").form()).toBeAny();
+  expectTypeOf(await client.get("/no-up-returned").form()).toBeAny();
+
+  expectTypeOf(await client.get("/up-returned").text()).toBeAny();
+  expectTypeOf(await client.get("/no-up-returned").text()).toBeAny();
+});
+
+test("infers based on schema passed to `r.output()`", async () => {
+  const Router = dredgeRouter([
+    r
+      .path("/string")
+      .get()
+      .output(z.string())
+      .use((_req, res) => {
+        return res.up({
+          data: "a",
+        });
+      }),
+    r
+      .path("/number")
+      .get()
+      .output(z.number())
+      .use((_req, res) => {
+        return res.up({
+          data: 1,
+        });
+      }),
+    r
+      .path("/boolean")
+      .get()
+      .output(z.boolean())
+      .use((_req, res) => {
+        return res.up({
+          data: true,
+        });
+      }),
+  ]);
+
+  const client = createClient<typeof Router>();
+
+  expectTypeOf(await client.get("/string").data()).toBeString();
+  expectTypeOf(await client.get("/number").data()).toBeNumber();
+  expectTypeOf(await client.get("/boolean").data()).toBeBoolean();
+
+  expectTypeOf(await client.get("/string").json()).toBeString();
+  expectTypeOf(await client.get("/number").json()).toBeNumber();
+  expectTypeOf(await client.get("/boolean").json()).toBeBoolean();
+
+  expectTypeOf(await client.get("/string").form()).toBeString();
+  expectTypeOf(await client.get("/number").form()).toBeNumber();
+  expectTypeOf(await client.get("/boolean").form()).toBeBoolean();
+
+  expectTypeOf(await client.get("/string").text()).toBeString();
+  expectTypeOf(await client.get("/number").text()).toBeNumber();
+  expectTypeOf(await client.get("/boolean").text()).toBeBoolean();
+});
+
+test("infers type passed to `res.up( { data: ... } )` for the first time", async () => {
+  const Router = dredgeRouter([
+    dredgeRoute()
+      .path("/string")
+      .get()
+      .use((_req, res) => {
+        return res.up({
+          data: "a",
+        });
+      }),
+    dredgeRoute()
+      .path("/number")
+      .get()
+      .use((_req, res) => {
+        return res.up({
+          data: 1,
+        });
+      }),
+    dredgeRoute()
+      .path("/boolean")
+      .get()
+      .use((_req, res) => {
+        return res.up({
+          data: true,
+        });
+      }),
+  ]);
+
+  const client = createClient<typeof Router>();
+
+  expectTypeOf(await client.get("/string").data()).toBeString();
+  expectTypeOf(await client.get("/number").data()).toBeNumber();
+  expectTypeOf(await client.get("/boolean").data()).toBeBoolean();
 });

--- a/packages/types/test/path-routes.ts
+++ b/packages/types/test/path-routes.ts
@@ -1,13 +1,13 @@
+import z from "zod";
 import { dredgeRoute } from "./helpers/dredge-route";
 import { dredgeRouter } from "./helpers/dredge-router";
-import z from "zod";
 
 export const singleParamNonAutoRouter = dredgeRouter([
   dredgeRoute()
     .path("/a/b/c/d")
     .get()
     .use((_req, res) => {
-      return res.end({
+      return res.up({
         data: "GET/a/b/c/d" as const,
       });
     }),
@@ -16,7 +16,7 @@ export const singleParamNonAutoRouter = dredgeRouter([
     .path("/a/b/c/d")
     .delete()
     .use((_req, res) => {
-      return res.end({
+      return res.up({
         data: "DELETE/a/b/c/d" as const,
       });
     }),
@@ -25,7 +25,7 @@ export const singleParamNonAutoRouter = dredgeRouter([
     .path("/:a/b/c/d")
     .get()
     .use((_req, res) => {
-      return res.end({
+      return res.up({
         data: "GET/:a/b/c/d" as const,
       });
     }),
@@ -35,7 +35,7 @@ export const singleParamNonAutoRouter = dredgeRouter([
     .put()
     .input(z.any())
     .use((_req, res) => {
-      return res.end({
+      return res.up({
         data: "PUT/:a/b/c/d" as const,
       });
     }),
@@ -47,7 +47,7 @@ export const singleParamNonAutoRouter = dredgeRouter([
       b: z.number(),
     })
     .use((_req, res) => {
-      return res.end({
+      return res.up({
         data: "GET/a/:b/c/d" as const,
       });
     }),
@@ -59,7 +59,7 @@ export const singleParamNonAutoRouter = dredgeRouter([
     })
     .get()
     .use((_req, res) => {
-      return res.end({
+      return res.up({
         data: "GET/a/b/:c/d" as const,
       });
     }),
@@ -71,7 +71,7 @@ export const singleParamNonAutoRouter = dredgeRouter([
     })
     .get()
     .use((_req, res) => {
-      return res.end({
+      return res.up({
         data: "GET/a/b/c/:d" as const,
       });
     }),
@@ -86,7 +86,7 @@ export const singleParamAutoRouter = dredgeRouter([
     })
     .get()
     .use((_req, res) => {
-      return res.end({
+      return res.up({
         data: "GET/:e/f/g/h" as const,
       });
     }),
@@ -97,7 +97,7 @@ export const singleParamAutoRouter = dredgeRouter([
     })
     .get()
     .use((_req, res) => {
-      return res.end({
+      return res.up({
         data: "GET/e/:f/g/h" as const,
       });
     }),
@@ -108,7 +108,7 @@ export const singleParamAutoRouter = dredgeRouter([
     })
     .get()
     .use((_req, res) => {
-      return res.end({
+      return res.up({
         data: "GET/e/f/:g/h" as const,
       });
     }),
@@ -119,7 +119,7 @@ export const singleParamAutoRouter = dredgeRouter([
     })
     .get()
     .use((_req, res) => {
-      return res.end({
+      return res.up({
         data: "GET/e/f/g/:h" as const,
       });
     }),
@@ -135,7 +135,7 @@ export const doubleParamNonAutoRouter = dredgeRouter([
     })
     .get()
     .use((_req, res) => {
-      return res.end({
+      return res.up({
         data: "GET/:s/t/:u/v/w/x" as const,
       });
     }),
@@ -147,7 +147,7 @@ export const doubleParamNonAutoRouter = dredgeRouter([
     })
     .get()
     .use((_req, res) => {
-      return res.end({
+      return res.up({
         data: "GET/s/:t/u/:v/w/x" as const,
       });
     }),
@@ -159,7 +159,7 @@ export const doubleParamNonAutoRouter = dredgeRouter([
     })
     .get()
     .use((_req, res) => {
-      return res.end({
+      return res.up({
         data: "GET/s/t/u/v/:w/:x" as const,
       });
     }),
@@ -174,7 +174,7 @@ export const doubleParamAutoRouter = dredgeRouter([
     })
     .get()
     .use((_req, res) => {
-      return res.end({
+      return res.up({
         data: "GET/:p/q/:r/s/t/u" as const,
       });
     }),
@@ -186,7 +186,7 @@ export const doubleParamAutoRouter = dredgeRouter([
     })
     .get()
     .use((_req, res) => {
-      return res.end({
+      return res.up({
         data: "/GET/p/:q/r/:s/t/u" as const,
       });
     }),
@@ -198,7 +198,7 @@ export const doubleParamAutoRouter = dredgeRouter([
     })
     .get()
     .use((_req, res) => {
-      return res.end({
+      return res.up({
         data: "GET/p/q/r/s/:t/:u" as const,
       });
     }),

--- a/packages/types/test/route.test-d.ts
+++ b/packages/types/test/route.test-d.ts
@@ -1,178 +1,181 @@
-import { inferRouteEData, inferRouteOData } from "../source/route/route-data";
-import { inferRouteDataTypes } from "../source/route/route-options";
-import { Simplify } from "../source/utils";
 import { describe, expectTypeOf, test } from "vitest";
 import { z } from "zod";
+import { inferRouteDataTypes } from "../source/route/route-options";
+import { Simplify } from "../source/utils";
 import { dredgeRoute } from "./helpers/dredge-route";
 
-describe("route.options()", () => {
-  test("invalid dataType should return string type", () => {
-    const route = dredgeRoute().options({
-      dataTypes: {
-        status: "any/any",
-      },
+describe("req", () => {
+  describe("route.options()", () => {
+    test("returns  error string when invalid dataType is passed", () => {
+      const route = dredgeRoute().options({
+        dataTypes: {
+          status: "any/any",
+        },
+      });
+
+      expectTypeOf(route).toBeString();
+    });
+    test("merges types when passed more than once", () => {
+      const route = dredgeRoute()
+        .options({
+          dataTypes: {
+            json: "application/json",
+            formData: "application/form-data",
+          },
+        })
+        .options({})
+        .options({
+          dataTypes: {
+            formData: "application/form",
+            xml: "application/xml",
+          },
+        })
+        .path("/test")
+        .get();
+
+      type DataTypes = Simplify<inferRouteDataTypes<typeof route>>;
+
+      expectTypeOf<DataTypes>().toEqualTypeOf<{
+        readonly json: "application/json";
+        readonly formData: "application/form-data";
+        readonly xml: "application/xml";
+      }>();
+    });
+  });
+
+  describe("req.data", () => {
+    test("infers `any` when middleware is defined before defining method", () => {
+      dredgeRoute()
+        .path("/test")
+        .use((req) => {
+          expectTypeOf(req.data).toBeAny();
+        });
     });
 
-    expectTypeOf(route).toBeString();
-  });
-  test("merging of dataTypes should work -- previous value should have priority", () => {
-    const route = dredgeRoute()
-      .options({
-        dataTypes: {
-          json: "application/json",
-          formData: "application/form-data",
-        },
-      })
-      .options({})
-      .options({
-        dataTypes: {
-          formData: "application/form",
-          xml: "application/xml",
-        },
-      })
-      .path("/test")
-      .get();
+    test("infers `undefined` when method is get, delete or head", () => {
+      dredgeRoute()
+        .path("/test")
+        .get()
+        .use((req) => {
+          expectTypeOf(req.data).toBeUndefined();
+        })
+        .error((_err, req) => {
+          expectTypeOf(req.data).toBeUndefined();
+        });
 
-    type DataTypes = Simplify<inferRouteDataTypes<typeof route>>;
+      dredgeRoute()
+        .path("/test")
+        .delete()
+        .use((req) => {
+          expectTypeOf(req.data).toBeUndefined();
+        })
+        .error((_err, req) => {
+          expectTypeOf(req.data).toBeUndefined();
+        });
 
-    expectTypeOf<DataTypes>().toEqualTypeOf<{
-      readonly json: "application/json";
-      readonly formData: "application/form-data";
-      readonly xml: "application/xml";
-    }>();
-  });
-});
+      dredgeRoute()
+        .path("/test")
+        .head()
+        .use((req) => {
+          expectTypeOf(req.data).toBeUndefined();
+        })
+        .error((_err, req) => {
+          expectTypeOf(req.data).toBeUndefined();
+        });
+    });
 
-describe("req", () => {
-  test("data should be any, if middleware is defined before defining the method", () => {
-    dredgeRoute()
-      .path("/test")
-      .use((req) => {
-        expectTypeOf(req.data).toBeAny();
-      });
-  });
+    test("infers `any` for error middleware", () => {
+      dredgeRoute()
+        .path("/test")
+        .error((_err, req) => {
+          expectTypeOf(req.data).toBeAny();
+        })
+        .post()
+        .input(z.string())
+        .error((_err, req) => {
+          expectTypeOf(req.data).toBeAny();
+        });
 
-  test("req.data for get, delete and head should be undefined", () => {
-    dredgeRoute()
-      .path("/test")
-      .get()
-      .use((req) => {
-        expectTypeOf(req.data).toBeUndefined();
-      })
-      .error((_err, req) => {
-        expectTypeOf(req.data).toBeUndefined();
-      });
+      dredgeRoute()
+        .path("/test")
+        .error((_err, req) => {
+          expectTypeOf(req.data).toBeAny();
+        })
+        .put()
+        .input(z.number())
+        .error((_err, req) => {
+          expectTypeOf(req.data).toBeAny();
+        });
 
-    dredgeRoute()
-      .path("/test")
-      .delete()
-      .use((req) => {
-        expectTypeOf(req.data).toBeUndefined();
-      })
-      .error((_err, req) => {
-        expectTypeOf(req.data).toBeUndefined();
-      });
+      dredgeRoute()
+        .path("/test")
+        .error((_err, req) => {
+          expectTypeOf(req.data).toBeAny();
+        })
+        .patch()
+        .input(z.null())
+        .error((_err, req) => {
+          expectTypeOf(req.data).toBeAny();
+        });
+    });
 
-    dredgeRoute()
-      .path("/test")
-      .head()
-      .use((req) => {
-        expectTypeOf(req.data).toBeUndefined();
-      })
-      .error((_err, req) => {
-        expectTypeOf(req.data).toBeUndefined();
-      });
-  });
+    test("infers `any` when parser is not provided and method is post, put or patch", () => {
+      dredgeRoute()
+        .path("/test")
+        .post()
+        .use((req) => {
+          expectTypeOf(req.data).not.toBeUndefined();
+          expectTypeOf(req.data).toBeAny();
+        });
 
-  test("req.data should always be any in error for method which takes data", () => {
-    dredgeRoute()
-      .path("/test")
-      .error((_err, req) => {
-        expectTypeOf(req.data).toBeAny();
-      })
-      .post()
-      .input(z.string())
-      .error((_err, req) => {
-        expectTypeOf(req.data).toBeAny();
-      });
+      dredgeRoute()
+        .path("/test")
+        .put()
+        .use((req) => {
+          expectTypeOf(req.data).not.toBeUndefined();
+          expectTypeOf(req.data).toBeAny();
+        });
 
-    dredgeRoute()
-      .path("/test")
-      .error((_err, req) => {
-        expectTypeOf(req.data).toBeAny();
-      })
-      .put()
-      .input(z.number())
-      .error((_err, req) => {
-        expectTypeOf(req.data).toBeAny();
-      });
+      dredgeRoute()
+        .path("/test")
+        .patch()
+        .use((req) => {
+          expectTypeOf(req.data).not.toBeUndefined();
+          expectTypeOf(req.data).toBeAny();
+        });
+    });
 
-    dredgeRoute()
-      .path("/test")
-      .error((_err, req) => {
-        expectTypeOf(req.data).toBeAny();
-      })
-      .patch()
-      .input(z.null())
-      .error((_err, req) => {
-        expectTypeOf(req.data).toBeAny();
-      });
-  });
+    test("infers the type provided to input", () => {
+      dredgeRoute()
+        .path("/test")
+        .post()
+        .input(z.string())
+        .use((req) => {
+          expectTypeOf(req.data).not.toBeUndefined();
+          expectTypeOf(req.data).toBeString();
+        });
 
-  test("req.data for post, put and patch should be any, if parser is not given", () => {
-    dredgeRoute()
-      .path("/test")
-      .post()
-      .use((req) => {
-        expectTypeOf(req.data).not.toBeUndefined();
-        expectTypeOf(req.data).toBeAny();
-      });
+      dredgeRoute()
+        .path("/test")
+        .put()
+        .input(z.number())
+        .use((req) => {
+          expectTypeOf(req.data).not.toBeUndefined();
+          expectTypeOf(req.data).toBeNumber();
+        });
 
-    dredgeRoute()
-      .path("/test")
-      .put()
-      .use((req) => {
-        expectTypeOf(req.data).not.toBeUndefined();
-        expectTypeOf(req.data).toBeAny();
-      });
-
-    dredgeRoute()
-      .path("/test")
-      .patch()
-      .use((req) => {
-        expectTypeOf(req.data).not.toBeUndefined();
-        expectTypeOf(req.data).toBeAny();
-      });
+      dredgeRoute()
+        .path("/test")
+        .patch()
+        .input(z.null())
+        .use((req) => {
+          expectTypeOf(req.data).not.toBeUndefined();
+          expectTypeOf(req.data).toBeNull();
+        });
+    });
   });
 
-  test("req.data should have correct type", () => {
-    dredgeRoute()
-      .path("/test")
-      .post()
-      .input(z.string())
-      .use((req) => {
-        expectTypeOf(req.data).not.toBeUndefined();
-        expectTypeOf(req.data).toBeString();
-      });
-
-    dredgeRoute()
-      .path("/test")
-      .put()
-      .input(z.number())
-      .use((req) => {
-        expectTypeOf(req.data).not.toBeUndefined();
-        expectTypeOf(req.data).toBeNumber();
-      });
-
-    dredgeRoute()
-      .path("/test")
-      .patch()
-      .input(z.null())
-      .use((req) => {
-        expectTypeOf(req.data).not.toBeUndefined();
-        expectTypeOf(req.data).toBeNull();
-      });
-  });
+  describe("req.params()", () => {});
 
   test("req.param()", () => {
     dredgeRoute()
@@ -254,23 +257,31 @@ describe("req", () => {
       });
   });
 
-  test("req.header()", () => {
+  test("req.header return `Record<string, string>` when given no argument", () => {
     dredgeRoute()
       .use((req) => {
         expectTypeOf(req.header()).toEqualTypeOf<Record<string, string>>();
+      })
+      .error((_err, req) => {
+        expectTypeOf(req.header()).toEqualTypeOf<Record<string, string>>();
+      });
+  });
+
+  test("req.header return `string | undefined` when given a string argument", () => {
+    dredgeRoute()
+      .use((req) => {
         expectTypeOf(req.header("content-type")).toEqualTypeOf<
           string | undefined
         >();
       })
-      .error((_err, req, _res) => {
-        expectTypeOf(req.header()).toEqualTypeOf<Record<string, string>>();
+      .error((_err, req) => {
         expectTypeOf(req.header("content-type")).toEqualTypeOf<
           string | undefined
         >();
       });
   });
 
-  test("req.url", () => {
+  test("req.url infers `string`", () => {
     dredgeRoute()
       .use((req) => {
         expectTypeOf(req.url).toBeString();
@@ -287,7 +298,7 @@ describe("req", () => {
       });
   });
 
-  test("req.method should be string in middlewares which are defined before defining method", () => {
+  test("req.method infers `string` when defined before defining method", () => {
     dredgeRoute()
       .use((req) => {
         expectTypeOf(req.method).not.toEqualTypeOf<"get">();
@@ -300,7 +311,7 @@ describe("req", () => {
       .get();
   });
 
-  test("req.method", () => {
+  test("req.method infers based on method definition", () => {
     dredgeRoute()
       .get()
       .use((req) => {
@@ -340,115 +351,86 @@ describe("req", () => {
 });
 
 describe("res", () => {
-  test("res.header", () => {
-    dredgeRoute()
-      .use((_req, res) => {
-        expectTypeOf(res.header()).toEqualTypeOf<Record<string, string>>();
-        expectTypeOf(res.header("content-type")).toEqualTypeOf<
-          string | undefined
-        >();
-      })
-      .error((_err, _req, res) => {
-        expectTypeOf(res.header()).toEqualTypeOf<Record<string, string>>();
-        expectTypeOf(res.header("content-type")).toEqualTypeOf<
-          string | undefined
-        >();
-      });
-  });
-
-  test("data in res.next option parameter", () => {
-    type ExpectedHeaders = Record<string, string | null> | undefined;
-    type ExpectedDataTypes = "json" | "form" | undefined;
-
-    type ExpectedNextTypes =
-      | {
-          data?: any;
-          ctx?: unknown;
-          headers?: ExpectedHeaders;
-          status?: number | undefined;
-          statusText?: string | undefined;
-          dataType?: ExpectedDataTypes;
-        }
-      | {
-          json?: any;
-          ctx?: unknown;
-          headers?: ExpectedHeaders;
-          status?: number | undefined;
-          statusText?: string | undefined;
-          dataType?: ExpectedDataTypes;
-        }
-      | {
-          form?: any;
-          ctx?: unknown;
-          headers?: ExpectedHeaders;
-          status?: number | undefined;
-          statusText?: string | undefined;
-          dataType?: ExpectedDataTypes;
-        };
-
-    type ExpectedEndTypes<T = any> =
-      | {
-          data?: T;
-          headers?: ExpectedHeaders;
-          status?: number | undefined;
-          statusText?: string | undefined;
-          dataType?: ExpectedDataTypes;
-        }
-      | {
-          json?: T;
-          headers?: ExpectedHeaders;
-          status?: number | undefined;
-          statusText?: string | undefined;
-          dataType?: ExpectedDataTypes;
-        }
-      | {
-          form?: T;
-          headers?: ExpectedHeaders;
-          status?: number | undefined;
-          statusText?: string | undefined;
-          dataType?: ExpectedDataTypes;
-        };
-
+  test("data field in res.up() extends to `any` when r.output() has not been called", () => {
     dredgeRoute()
       .options({
         dataTypes: {
           json: "application/json",
-          form: "application/form-data",
         },
       })
+      .path("/test")
       .use((_req, res) => {
-        type NextParameter = Simplify<Parameters<typeof res.next>[0]>;
-        type EndParameter = Simplify<Parameters<typeof res.end>[0]>;
+        type UpParameter = Simplify<Parameters<typeof res.up>[0]>;
 
-        expectTypeOf<NextParameter>().toEqualTypeOf<ExpectedNextTypes>();
-        expectTypeOf<EndParameter>().toEqualTypeOf<ExpectedEndTypes>();
+        expectTypeOf<UpParameter["data"]>().toBeAny();
+        expectTypeOf<UpParameter["json"]>().toBeAny();
       })
       .error((_err, _req, res) => {
-        type NextParameter = Simplify<Parameters<typeof res.next>[0]>;
-        type EndParameter = Simplify<Parameters<typeof res.end>[0]>;
-
-        expectTypeOf<NextParameter>().toEqualTypeOf<ExpectedNextTypes>();
-        expectTypeOf<EndParameter>().toEqualTypeOf<ExpectedEndTypes>();
-      })
-      .output(z.string())
-      .use((_req, res) => {
-        type NextParameter = Simplify<Parameters<typeof res.next>[0]>;
-        type EndParameter = Simplify<Parameters<typeof res.end>[0]>;
-
-        expectTypeOf<NextParameter>().toEqualTypeOf<ExpectedNextTypes>();
-        expectTypeOf<EndParameter>().toEqualTypeOf<ExpectedEndTypes<string>>();
+        type UpParameter = Simplify<Parameters<typeof res.up>[0]>;
+        expectTypeOf<UpParameter["data"]>().toBeAny();
+        expectTypeOf<UpParameter["json"]>().toBeAny();
       });
   });
 
-  test("res.ctx in use()", () => {
-    dredgeRoute<{ db: "fake-db"; session: { username: string } }>()
+  test("data field in res.up() extends to whatever passed to r.output()", () => {
+    dredgeRoute()
+      .options({
+        dataTypes: {
+          json: "application/json",
+        },
+      })
+      .path("/test")
+      .output(z.enum(["a", "b", "c"]))
       .use((_req, res) => {
-        expectTypeOf(res.ctx).toEqualTypeOf<{
-          db: "fake-db";
-          session: { username: string };
-        }>();
+        type UpParameter = Simplify<Parameters<typeof res.up>[0]>;
+        type ExpectedDataTypes = "a" | "b" | "c" | undefined;
 
-        return res.next({
+        expectTypeOf<UpParameter["data"]>().toEqualTypeOf<ExpectedDataTypes>();
+        expectTypeOf<UpParameter["json"]>().toEqualTypeOf<ExpectedDataTypes>();
+      });
+  });
+
+  test("data field in res.up() extends to whatever passed to res.up() for the first time", () => {
+    dredgeRoute()
+      .options({
+        dataTypes: {
+          json: "application/json",
+        },
+      })
+      .path("/test")
+      .use((_req, res) => {
+        let data = "a" as "a" | "b" | "c";
+        return res.up({
+          data,
+        });
+      })
+      .use((_req, res) => {
+        type UpParameter = Simplify<Parameters<typeof res.up>[0]>;
+        type ExpectedDataTypes = "a" | "b" | "c" | undefined;
+
+        expectTypeOf<UpParameter["data"]>().toEqualTypeOf<ExpectedDataTypes>();
+        expectTypeOf<UpParameter["json"]>().toEqualTypeOf<ExpectedDataTypes>();
+      });
+  });
+
+  test("res.ctx infers InitialContext in the beginning", () => {
+    type InitialContext = { db: "fake-db"; session: { username: string } };
+
+    dredgeRoute<InitialContext>()
+      .use((_req, res) => {
+        expectTypeOf(res.ctx).toEqualTypeOf<InitialContext>();
+      })
+      .error((_err, _req, res) => {
+        expectTypeOf(res.ctx).toEqualTypeOf<InitialContext>();
+      });
+  });
+
+  test("`res.up({ctx: ... })` mutates res.ctx", () => {
+    type InitialContext = { db: "fake-db"; session: { username: string } };
+
+    dredgeRoute<InitialContext>()
+      .use((_req, res) => {
+        return res.up({
           ctx: {
             meta: { info: "...." },
             session: {
@@ -466,7 +448,7 @@ describe("res", () => {
       })
       .use(() => {})
       .use((_req, res) => {
-        return res.next({
+        return res.up({
           ctx: {
             session: {
               userId: "1",
@@ -481,17 +463,10 @@ describe("res", () => {
           db: "fake-db";
         }>();
       });
-  });
 
-  test("res.ctx in error()", () => {
-    dredgeRoute<{ db: "fake-db"; session: { username: string } }>()
+    dredgeRoute<InitialContext>()
       .error((_err, _req, res) => {
-        expectTypeOf(res.ctx).toEqualTypeOf<{
-          db: "fake-db";
-          session: { username: string };
-        }>();
-
-        return res.next({
+        return res.up({
           ctx: {
             meta: { info: "...." },
             session: {
@@ -509,7 +484,7 @@ describe("res", () => {
       })
       .error(() => {})
       .error((_err, _req, res) => {
-        return res.next({
+        return res.up({
           ctx: {
             session: {
               userId: "1",
@@ -526,148 +501,7 @@ describe("res", () => {
       });
   });
 
-  test("OData should be any, if res.end() is returned without data and same with EData", () => {
-    const routeI = dredgeRoute()
-      .path("/test")
-      .get()
-      .use((_req, res) => {
-        return res.end({ status: 200 });
-      })
-      .error((_err, _req, res) => {
-        return res.end({ status: 200 });
-      });
-
-    type ODataI = inferRouteOData<typeof routeI>;
-    expectTypeOf<ODataI>().toEqualTypeOf<any>();
-    type EDataI = inferRouteEData<typeof routeI>;
-    expectTypeOf<EDataI>().toEqualTypeOf<any>();
-
-    const routeII = dredgeRoute()
-      .path("/test")
-      .get()
-      .use((_req, res) => {
-        return res.end();
-      })
-      .error((_err, _req, res) => {
-        return res.end();
-      });
-
-    type ODataII = inferRouteOData<typeof routeII>;
-    expectTypeOf<ODataII>().toEqualTypeOf<any>();
-    type EDataII = inferRouteEData<typeof routeII>;
-    expectTypeOf<EDataII>().toEqualTypeOf<any>();
-  });
-
-  test("OData should stay never, if res.end() is not returned and same with EData", () => {
-    const routeO = dredgeRoute().path("/test").get();
-
-    type ODataO = inferRouteOData<typeof routeO>;
-    expectTypeOf<ODataO>().toBeNever();
-    type EDataO = inferRouteEData<typeof routeO>;
-    expectTypeOf<EDataO>().toBeNever();
-
-    const routeI = dredgeRoute()
-      .path("/test")
-      .get()
-      .use((_req, _res) => {})
-      .error((_err, _req, _res) => {});
-
-    type ODataI = inferRouteOData<typeof routeI>;
-    expectTypeOf<ODataI>().toBeNever();
-    type EDataI = inferRouteEData<typeof routeI>;
-    expectTypeOf<EDataI>().toBeNever();
-
-    const routeII = dredgeRoute()
-      .path("/test")
-      .get()
-      .use((_req, res) => {
-        return res.next({
-          ctx: {
-            session: 1,
-          },
-          status: 200,
-        });
-      })
-      .error((_err, _req, res) => {
-        return res.next({
-          ctx: {
-            session: 1,
-          },
-          status: 200,
-        });
-      });
-
-    type ODataII = inferRouteOData<typeof routeII>;
-    expectTypeOf<ODataII>().toBeNever();
-    type EDataII = inferRouteEData<typeof routeII>;
-    expectTypeOf<EDataII>().toBeNever();
-
-    const routeIII = dredgeRoute()
-      .path("/test")
-      .get()
-      .use((_req, res) => {
-        return res.next({
-          data: "...",
-        });
-      })
-      .error((_err, _req, res) => {
-        return res.next({
-          data: "...",
-        });
-      });
-
-    type ODataIII = inferRouteOData<typeof routeIII>;
-    expectTypeOf<ODataIII>().toBeNever();
-    type EDataIII = inferRouteEData<typeof routeIII>;
-    expectTypeOf<EDataIII>().toBeNever();
-
-    const routeIV = dredgeRoute()
-      .path("/test")
-      .get()
-      .use((_req, _res) => {})
-      .use((_req, res) => {
-        return res.next();
-      })
-      .error((_err, _req, res) => {
-        return res.next();
-      });
-
-    type ODataIV = inferRouteOData<typeof routeIV>;
-    expectTypeOf<ODataIV>().toBeNever();
-    type EDataIV = inferRouteEData<typeof routeIV>;
-    expectTypeOf<EDataIV>().toBeNever();
-  });
-
-  test("res.end and responseData", () => {
-    const route = dredgeRoute()
-      .path("/test")
-      .get()
-      .use((_req, res) => {
-        return res.end({
-          data: "this is string" as const,
-        });
-      });
-
-    type OData = inferRouteOData<typeof route>;
-    expectTypeOf<OData>().toEqualTypeOf<"this is string">();
-  });
-
-  test("route.output and responseData", () => {
-    const route = dredgeRoute()
-      .path("/test")
-      .get()
-      .output(z.enum(["a", "b", "c"]))
-      .use((_req, res) => {
-        return res.end({
-          data: "a",
-        });
-      });
-
-    type OData = inferRouteOData<typeof route>;
-    expectTypeOf<OData>().toEqualTypeOf<"a" | "b" | "c">();
-  });
-
-  test("res.data should always be `any`", () => {
+  test("res.data infers `any`", () => {
     dredgeRoute()
       .path("/test")
       .get()
@@ -677,7 +511,7 @@ describe("res", () => {
       .use(() => {})
       .use((_req, res) => {
         expectTypeOf(res.data).toBeAny();
-        return res.next({
+        return res.up({
           data: [1, 2, 3],
         });
       })
@@ -698,7 +532,7 @@ describe("res", () => {
       .error(() => {})
       .error((_err, _req, res) => {
         expectTypeOf(res.data).toBeAny();
-        return res.next({
+        return res.up({
           data: [1, 2, 3],
         });
       })
@@ -707,16 +541,50 @@ describe("res", () => {
       });
   });
 
-  test("res.status and res.statusText", () => {
+  test("res.header() returns `Record<string, string>` when given no argument", () => {
+    dredgeRoute()
+      .use((_req, res) => {
+        expectTypeOf(res.header()).toEqualTypeOf<Record<string, string>>();
+      })
+      .error((_err, _req, res) => {
+        expectTypeOf(res.header()).toEqualTypeOf<Record<string, string>>();
+      });
+  });
+
+  test("res.header() returns `string | undefined` when given a string argument", () => {
+    dredgeRoute()
+      .use((_req, res) => {
+        expectTypeOf(res.header("content-type")).toEqualTypeOf<
+          string | undefined
+        >();
+      })
+      .error((_err, _req, res) => {
+        expectTypeOf(res.header("content-type")).toEqualTypeOf<
+          string | undefined
+        >();
+      });
+  });
+
+  test("res.status infers `number | undefined`", () => {
     dredgeRoute()
       .path("/test")
       .get()
       .use((_req, res) => {
         expectTypeOf(res.status).toEqualTypeOf<number | undefined>();
+      })
+      .error((_err, _req, res) => {
+        expectTypeOf(res.status).toEqualTypeOf<number | undefined>();
+      });
+  });
+
+  test("res.statusText infers `string | undefined`", () => {
+    dredgeRoute()
+      .path("/test")
+      .get()
+      .use((_req, res) => {
         expectTypeOf(res.statusText).toEqualTypeOf<string | undefined>();
       })
       .error((_err, _req, res) => {
-        expectTypeOf(res.status).toEqualTypeOf<number | undefined>();
         expectTypeOf(res.statusText).toEqualTypeOf<string | undefined>();
       });
   });


### PR DESCRIPTION
removes `res.next()` and `res.end()` from dredge-route